### PR TITLE
Added "external_tools" category

### DIFF
--- a/external_tools/README
+++ b/external_tools/README
@@ -1,0 +1,3 @@
+Useful tools and utilities for interacting with CFEngine, but that are not CFEngine policy code.
+
+Examples: git/svn hooks, pre/post processing scripts, etc.


### PR DESCRIPTION
Useful tools and utilities for interacting with CFEngine, but that are not CFEngine policy code.

Examples: git/svn hooks, pre/post processing scripts, etc.
