### PR TITLE
Add sketch to upgrade to CFEngine 3.3.0 via rpm working around bug 1068

### DIFF
--- a/policy_examples/upgrade_cfengine_3_3_0_rpm/README.md
+++ b/policy_examples/upgrade_cfengine_3_3_0_rpm/README.md
@@ -1,0 +1,46 @@
+# upgrade_cfengine_3_3_0_rpm - Upgrade to CFEngine  Community 3.3.0 via rpm
+## AUTHOR
+Nick Anderson <nick@cmdln.org>
+
+## PLATFORM
+linux
+
+## DESCRIPTION
+The 3.3.0-1 rpm release has a few bugs that could leave your agents unable to
+execute or update policy. See [bug 1068](https://cfengine.com/bugtracker/view.php?id=1068) 
+for details.
+
+This sketch works around those bugs to make sure your agents are upgraded and
+can continue to get policy updates. Its kind of sloppy sorry.
+
+## REQUIREMENTS
+CFEngine community 3.3.0-1 rpms need to be downloaded from the [engine
+room](http://cfengine.com/inside/myspace) (free registration required) 
+and placed in the files/packages directory.
+
+## SAMPLE USAGE
+
+    body common control
+    {
+     bundlesequence => { "main" };
+
+     inputs => { 
+                "cfengine_stdlib.cf", 
+                "sketches/upgrade_cfengine_3_3_0_rpm/upgrade_cfengine_3_3_0_rpm.cf", 
+               };
+
+     version => "Community Promises.cf 1.0.0";
+    }
+
+    bundle agent main
+    {
+     reports:
+      cfengine_3::
+       "--> CFE is running on $(sys.fqhost)"
+          comment => "Display message on screen/email",
+           handle => "main_reports_cfe_running";
+
+    methods:
+        "any" usebundle => upgrade_cfengine_3_3_0_rpm;
+    }
+

--- a/policy_examples/upgrade_cfengine_3_3_0_rpm/files/packages/README.md
+++ b/policy_examples/upgrade_cfengine_3_3_0_rpm/files/packages/README.md
@@ -1,0 +1,8 @@
+# Packages
+The following files should be in this directory.
+
+  * cfengine-community-3.3.0-1.i386.rpm
+  * cfengine-community-3.3.0-1.x86_64.rpm
+
+You must source them from the 
+[engine room](http://cfengine.com/inside/myspace).

--- a/policy_examples/upgrade_cfengine_3_3_0_rpm/metadata.txt
+++ b/policy_examples/upgrade_cfengine_3_3_0_rpm/metadata.txt
@@ -1,0 +1,5 @@
+author:Nick Anderson <nick@cmdln.org>
+ostype:linux
+tested:redhat_5, 
+cfengine_version: community-3.2.1
+

--- a/policy_examples/upgrade_cfengine_3_3_0_rpm/test/README.md
+++ b/policy_examples/upgrade_cfengine_3_3_0_rpm/test/README.md
@@ -1,0 +1,3 @@
+# Make Test
+
+I used this to resetup my enviornment while writing the sketch

--- a/policy_examples/upgrade_cfengine_3_3_0_rpm/test/makefile
+++ b/policy_examples/upgrade_cfengine_3_3_0_rpm/test/makefile
@@ -1,0 +1,18 @@
+
+all: meclean 3.2 upgrade
+
+upgrade:
+	rsync -av upgrade_cfengine_3_3_0_rpm /var/cfengine/masterfiles/sketches/
+	cp promises.cf /var/cfengine/masterfiles/promises.cf
+	
+3.2:
+	rpm -i cfengine-community-3.2.1-1.el5.x86_64.rpm
+	cf-agent -B -s 10.7.2.131
+	cf-agent -KIB
+	cf-agent -KI
+	/etc/init.d/cfengine3 start
+
+meclean: 
+	rpm -e cfengine-community
+	rm -rf /var/cfengine 
+	rm -rf /usr/local/sbin/*

--- a/policy_examples/upgrade_cfengine_3_3_0_rpm/test/promises.cf
+++ b/policy_examples/upgrade_cfengine_3_3_0_rpm/test/promises.cf
@@ -1,0 +1,248 @@
+###############################################################################
+#
+#   promises.cf - Basic Policy for Community
+#
+###############################################################################
+
+body common control
+{
+ bundlesequence => { "main" };
+
+ inputs => { 
+            "cfengine_stdlib.cf", 
+            "sketches/upgrade_cfengine_3_3_0_rpm/upgrade_cfengine_3_3_0_rpm.cf", 
+           };
+
+ version => "Community Promises.cf 1.0.0";
+}
+
+###############################################################################
+
+bundle agent main
+{
+ reports:
+  cfengine_3::
+   "--> CFE is running on $(sys.fqhost)"
+      comment => "Display message on screen/email",
+       handle => "main_reports_cfe_running";
+
+methods:
+    "any" usebundle => upgrade_cfengine_3_3_0_rpm;
+}
+
+###############################################################################
+#
+# common def
+#  - common/global variables and classes here  
+#
+###############################################################################
+
+bundle common def
+{
+ vars:
+
+  # Begin change # Your domain name, for use in access control
+
+     "domain"  string => "example.com",
+              comment => "Define a global domain for all hosts",
+               handle => "common_def_vars_domain";
+
+  # List here the IP masks that we grant access to on the server
+
+    "acl" slist => { 
+                   "$(sys.policy_hub)/16"  # Assume /16 LAN clients to start with
+
+                 #  "2001:700:700:3.*", 
+                 #  "217.77.34.18", 
+                 #  "217.77.34.19",
+                   },
+       comment => "Define an acl for the machines to be granted accesses",
+        handle => "common_def_vars_acl"; 
+
+  # End change #
+
+  "dir_masterfiles" string => translatepath("$(sys.workdir)/masterfiles"),
+                   comment => "Define masterfiles path",
+                    handle => "common_def_vars_dir_masterfiles";
+
+}
+
+###############################################################################
+# This part is for cf-agent 
+#
+# Settings describing the details of the fixed behavioural promises made by 
+# cf-agent.
+###############################################################################
+
+body agent control
+
+{
+# Global default for time that must elapse before promise will be rechecked.
+# Don't keep any promises.
+
+ any::
+
+ # This should normally be set to an interval like 1-5 mins
+ # We set it to zero initially to avoid confusion.
+
+  ifelapsed => "0";
+
+ # Do not send IP/name during server connection if address resolution is broken.
+ # Comment it out if you do NOT have a problem with DNS
+
+  skipidentify => "true";
+
+ # Environment variables based on Distro
+
+ debian::
+  environment => { 
+                  "DEBIAN_FRONTEND=noninteractive",
+                 };
+
+}
+
+###############################################################################
+# This part is for cf-serverd
+#
+# Server controls are mainly about determining access policy for the connection 
+# protocol: i.e. access to the server itself. 
+# Access to specific files must be granted in addition. 
+###############################################################################
+
+body server control 
+{
+ denybadclocks         => "false";
+ allowconnects         => { "127.0.0.1" , "::1", @(def.acl) };
+ allowallconnects      => { "127.0.0.1" , "::1", @(def.acl) };
+ trustkeysfrom         => { "127.0.0.1" , "::1", @(def.acl) };
+
+ skipverify            => { ".*$(def.domain)", "127.0.0.1" , "::1", @(def.acl) };
+
+ allowusers            => { "root" };
+
+# Uncomment the line below to allow remote users to run 
+# cf-agent through cf-runagent
+
+# cfruncommand          => "$(sys.cf_agent)";
+}
+
+###############################################################################
+
+bundle server access_rules()
+{
+ access:
+
+  any::
+
+   "$(def.dir_masterfiles)"
+       handle => "server_access_grant_access_policy",
+      comment => "Grant access to the policy updates",
+      admit   => { ".*$(def.domain)", @(def.acl) };
+
+# Uncomment the promise below to allow cf-runagent to
+# access cf-agent on Windows machines
+#	
+#  "c:\program files\cfengine\bin\cf-agent.exe"
+#
+#    handle => "grant_access_policy_agent",
+#    comment => "Grant access to the agent (for cf-runagent)",
+#    admit   => { ".*$(def.domain)", @(def.acl) };	
+	
+ roles:
+
+# Use roles to allow specific remote cf-runagent users to
+# define certain soft-classes when running cf-agent on this host	
+#  "emergency"  authorize => { "root" };
+	
+}
+
+###############################################################################
+# This part is for cf-execd
+#
+# These body settings determine the behaviour of cf-execd, including scheduling
+# times and output capture to $(sys.workdir)/outputs and relay via email.
+###############################################################################
+
+body executor control
+{
+ any::
+
+  splaytime  => "1";
+  mailto     => "cfengine@$(def.domain)";
+  mailfrom   => "cfengine@$(sys.host).$(def.domain)";
+  smtpserver => "localhost";
+
+# Default:
+#
+# schedule => { "Min00", "Min05", "Min10", "Min15", "Min20", 
+#               "Min25", "Min30", "Min35", "Min40", "Min45",
+#               "Min50", "Min55" };
+
+# The full path and command to the executable run by default (overriding builtin).
+# cf-twin needs its own safe environment because of the update mechanism
+
+ linux::
+  exec_command => "$(sys.cf_twin) -f failsafe.cf && $(sys.cf_agent)";
+
+}
+
+###############################################################################
+# This part is for cf-report
+#
+# Determines a list of reports to write into the build directory. 
+# The format may be in text, html or xml format.
+###############################################################################
+
+body reporter control
+{
+ any::
+
+  reports => { 
+             "all" 
+             };
+
+  build_directory => "$(sys.workdir)/reports";
+  report_output   => "html";
+  style_sheet => "/cf_enterprise.css";
+
+}
+
+###############################################################################
+# This part is for cf-runagent
+#
+# The most important parameter here is the list of hosts that the agent will 
+# poll for connections.
+###############################################################################
+
+body runagent control
+{
+# A list of hosts to contact when using cf-runagent
+
+ any::
+
+  hosts => { "127.0.0.1" };
+
+# , "myhost.example.com:5308", ...
+
+}
+
+###############################################################################
+# This part is for cf-monitord
+#
+# The system defaults will be sufficient for most users. 
+# This configurability potential, however, will be a key to developing 
+# the integrated monitoring capabilities of CFE.
+###############################################################################
+
+body monitor control
+{
+ any::
+  forgetrate => "0.7";
+  histograms => "true";
+#  tcpdump => "false";
+#  tcpdumpcommand => "/usr/sbin/tcpdump -t -n -v";
+
+}
+
+###############################################################################
+

--- a/policy_examples/upgrade_cfengine_3_3_0_rpm/upgrade_cfengine_3_3_0_rpm.cf
+++ b/policy_examples/upgrade_cfengine_3_3_0_rpm/upgrade_cfengine_3_3_0_rpm.cf
@@ -1,0 +1,68 @@
+bundle agent upgrade_cfengine_3_3_0_rpm{
+    vars:
+	"bundlename" string => "upgrade_cfengine_3_3_0_rpm";
+        "dir_masterfiles" string => "/var/cfengine/masterfiles";
+
+        "files"
+            string => "sketches/upgrade_cfengine_3_3_0_rpm/files",
+            comment => "Path to sketch files relative to inputs or masterfiles";
+
+        "dir_packages" string => "$(sys.workdir)/inputs/$(files)/packages";
+
+
+        "files_refresh_interval"
+            string => "1440",
+            comment => "Time in minutes to refresh the files directory from the policy hub";
+
+        "package[cfengine-community][version]" string => "3.3.0-1";
+        "package[cfengine-community][policy]"  string => "update";
+
+	"packages" slist => getindices("$(bundlename).package");
+
+    files:
+        "$(sys.workdir)/inputs/$(files)/."
+            copy_from => sync_cp("$(dir_masterfiles)/$(files)/.", "$(sys.policy_hub)"),
+            depth_search => recurse("inf"),
+            action       => if_elapsed("$(files_refresh_interval)"),
+            comment      => "Sync sketch files directory locally";
+
+        # cf-twin is only used in the NOVA edition.
+        community_edition::
+
+	    "$(sys.workdir)/bin/cf-twin"
+                delete => tidy,
+                comment => "We need to remove cf-twin because it causes undefined symbol errors see bug 1068";
+
+            "/usr/local/sbin/cf-twin"
+                delete => tidy,
+                comment => "We need to remove cf-twin because it causes undefined symbol errors see bug 1068";
+
+    #packages:
+    #    "$(packages)"
+    #        package_policy => "$(package[$(packages)][policy])",
+    #        package_method => rpm_version("$(dir_packages)"),
+    #        package_select => ">=",
+    #        package_version => "$(package[$(packages)][version])",
+    #        package_architectures => { "$(sys.arch)" },
+    #        classes               => if_repaired("$(bundlename)_restart_cfengine"),
+    #        comment               => "Install the version $(package[$(packages)][version])
+    #                                  of the $(packages) rpm for the $(sys.arch) architecture";
+
+   processes:
+	"cf-execd"
+            restart_class => "$(bundlename)_restart_cfengine"; 
+
+    commands:
+        "/bin/rpm -UvH $(dir_packages)/$(packages)-$(package[$(packages)][version]).$(sys.arch).rpm"
+            classes => if_repaired("$(bundlename)_restart_cfengine"),
+            comment => "Versioning models from 3.2.1 -> 3.3.0 are incompatible so we just use rpm directly";
+
+        "/etc/init.d/cfengine3 restart"
+            ifvarclass => "$(bundlename)_restart_cfengine",
+            comment    => "Restart cfengine3 if its not running or after we have upgraded the rpm";
+
+    reports:
+        inform_mode::
+            "$(package[$(packages)][policy])";
+
+}


### PR DESCRIPTION
While upgrading from 3.2.1 to 3.3.0 I ran into a few issues documented in [bug 108](https://cfengine.com/bugtracker/view.php?id=1068). This sketch upgrades cfengine to 3.3.0-1 and works around those bugs. Its kind of ugly but I think it serves as a useful example, and it worked for me.

users will need to populate the packages directory in this sketch with the rpms from the engine room.
