### PR TITLE
file-based custom package installation sketch

### DIFF
--- a/package_management/filebased_execution/README.md
+++ b/package_management/filebased_execution/README.md
@@ -1,0 +1,36 @@
+# File-based package installation through custom execution
+
+##AUTHOR
+Eystein Måløy Stenberg <eystein@cfengine.com>
+
+##PLATFORM
+Windows
+
+##DESCRIPTION
+Scans a directory for any new or changed files. Any found .msi files are
+installed with msiexec, while any .bat and .exe files are executed in a shell
+environment. Does nothing with files not having any of these suffixes.
+Note that interactive installations/error dialogue boxes will cause problems 
+for automation (as always).
+
+##REQUIREMENTS
+ * A directory or share with package files, currently .msi, .bat and .exe are supported types
+ * cfengine_stdlib.cf
+
+##SAMPLE USAGE
+    body common control
+    {
+    bundlesequence => { "packages" };
+    inputs => { "cfengine_stdlib.cf", "filebased_execution.cf" };
+    }
+
+    bundle agent packages
+    {
+    methods:
+      "any" usebundle => filebased_execution( "\\\\myhost\repo" );
+    }
+
+##TODO
+ * Support Unix packages: take accepted file-types and respective managers as parameters
+ * Test with interactive installations, handle (abort and report) - with expireafter?
+ * Introduce native support in packages: promises to make this sketch obsolete

--- a/package_management/filebased_execution/filebased_execution.cf
+++ b/package_management/filebased_execution/filebased_execution.cf
@@ -1,0 +1,37 @@
+bundle agent filebased_execution(package_source_dir)
+{
+classes:
+ "has_packages" expression => isvariable("package_list");
+
+vars:
+  "package_list"            slist => lsdir("$(package_source_dir)", "", "true");
+
+has_packages::
+  "package_list_executable" slist => grep(".*\.(exe|bat)$", "package_list");  
+  "package_list_msi"        slist => grep(".*\.msi$", "package_list");
+
+
+files:
+
+windows.has_packages::
+  "$(package_list)"
+      comment => "Scan for file changes in repository",
+      changes => detect_content,
+      classes => if_repaired("package_file_changed_$(package_list)"),
+       handle => "filebased_execution_change_$(package_list)";
+  
+
+commands:
+
+  "$(package_list_executable)"
+       comment => "Run executable file if we have not seen it or it has changed",
+    ifvarclass => canonify("package_file_changed_$(package_list_executable)"),
+       contain => in_shell,
+        handle => "filebased_execution_install_executable_$(package_list_executable)";
+	
+  "\"$(sys.winsysdir)\msiexec.exe\" /qn /i $(package_list_msi)"
+       comment => "Install msi-file if we have not seen it or it has changed",
+    ifvarclass => canonify("package_file_changed_$(package_list_msi)"),
+        handle => "filebased_execution_install_msi_$(package_list_msi)";
+}
+

--- a/package_management/filebased_execution/metadata.txt
+++ b/package_management/filebased_execution/metadata.txt
@@ -1,0 +1,4 @@
+author: Eystein Måløy Stenberg <eystein@cfengine.com>
+ostype: windows
+tested: Windows_2008,Windows_7
+cfengine_version: core-3.3.0,nova-2.2.0


### PR DESCRIPTION
Simple bundle to install custom packages from a directory.
Currently only tested under Windows, but should work with minor modifications under Unix, if desirable.
