### PR TITLE
bring over filler/vagrant-cfengine

### DIFF
--- a/external_tools/vagrant-cfengine/.gitignore
+++ b/external_tools/vagrant-cfengine/.gitignore
@@ -1,0 +1,4 @@
+# Ignore the dot-vagrant file
+.vagrant
+# Ignore masterfiles clone
+masterfiles

--- a/external_tools/vagrant-cfengine/README.md
+++ b/external_tools/vagrant-cfengine/README.md
@@ -1,0 +1,21 @@
+vagrant-cfengine
+================
+- These are Vagrantfiles which can be fed to [vagrant](http://vagrantup.com/).
+- They aim to boostrap 64-bit el6 CentOS quickly with cfengine 3.3.1 installed on them.[1]
+- There is a rudimentary drop to a [vagrant shell provisioner](http://vagrantup.com/docs/provisioners/shell.html).[2]
+- Vagrant baseboxes built with vagrant 1.0.3, veewee 0.2.3, vbox 4.1.14.
+
+#### Quickstart
+    $ git clone git://github.com/filler/vagrant-cfengine.git
+    $ cd vagrant-cfengine
+    $ vagrant up
+
+#### Using the shell provisioner, local inputs/bundles
+    $ git clone git://github.com/filler/vagrant-cfengine.git && cd vagrant-cfengine
+    $ git clone git@github.com:filler/my-awesome-cf3-code.git masterfiles
+    $ vi Vagrantfile   # uncomment share + provision
+    $ vi cfengine3.sh   # as appropriate for null routes, tree manipulation, classes to invoke
+    $ vagrant up
+
+- [1]: This is done in the veewee template postinstall via cfengine-community packages (no EPEL).
+- [2]: This hack should be deprecated in-favor a vagrant-proper CFEngine provisioner.  Go forth and fork (or sponsor).

--- a/external_tools/vagrant-cfengine/Vagrantfile
+++ b/external_tools/vagrant-cfengine/Vagrantfile
@@ -1,0 +1,29 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# This Vagrantfile bootstraps two 64-bit CentOS 6 guests for hub and agent use
+# Put together by Nick Silkey <nick@silkey.org>
+#
+Vagrant::Config.run do |config|
+
+  # setup the box which will run cfhub
+  # simulates a policyserver/fileserver
+  config.vm.define :cfhub do |cfhub_config|
+    cfhub_config.vm.box = "CentOS-6.2-x86_64-minimal"
+    cfhub_config.vm.box_url = "http://dl.dropbox.com/u/5585354/CentOS-6.2-x86_64-minimal.box"
+    cfhub_config.vm.network :hostonly, "33.33.33.33"
+    # cfhub_config.vm.share_folder "masterfiles","/var/cfengine/masterfiles","./masterfiles/"
+    # cfhub_config.vm.provision :shell, :path => "cfengine3.sh"
+  end
+
+  # setup the box which will run cfagent
+  # simulates a client
+  config.vm.define :cfagent do |cfagent_config|
+    cfagent_config.vm.box = "CentOS-6.2-x86_64-minimal"
+    cfagent_config.vm.box_url = "http://dl.dropbox.com/u/5585354/CentOS-6.2-x86_64-minimal.box"
+    cfagent_config.vm.network :hostonly, "33.33.33.44"
+    # cfagent_config.vm.share_folder "masterfiles","/var/cfengine/masterfiles","./masterfiles/"
+    # cfagent_config.vm.provision :shell, :path => "cfengine3.sh"
+  end
+
+end

--- a/external_tools/vagrant-cfengine/cfengine3.sh
+++ b/external_tools/vagrant-cfengine/cfengine3.sh
@@ -1,0 +1,27 @@
+POLICYHOST="1.2.3.4"
+ENABLE_CLASSES="localDev,drupal7"
+
+#
+# Do you have a policyserver you never want to phone home to?
+# If so, null route them
+#
+# sudo netstat -nr
+# sudo ip route add blackhole ${POLICYHOST} 
+# sudo netstat -nr
+
+#
+# Do you need to move group.cf into place for workable tree?
+# I do since my code trees arent completely portable.
+#
+# sudo cp \
+# /var/cfengine/masterfiles/inputs/dcsunix/group.cf \
+# /var/cfengine/inputs/group.cf
+# sudo cp \
+# /var/cfengine/masterfiles/inputs/core/failsafe.cf \
+# /var/cfengine/inputs/failsafe.cf
+
+#
+# Run cf-agent twice, no locks, verbose, with poz-matched classes
+#
+sudo /var/cfengine/bin/cf-agent -Kv -D ${ENABLE_CLASSES}
+sudo /var/cfengine/bin/cf-agent -Kv -D ${ENABLE_CLASSES}


### PR DESCRIPTION
https://github.com/filler/vagrant-cfengine is a tested use case which allows a vagrant user to consume baseboxes to test hub v agent, local input development, shell-to-cfengine provisioning.  
