### PR TITLE
cfsketchify and make more generic

### DIFF
--- a/sketches/system/etc_hosts/README.md
+++ b/sketches/system/etc_hosts/README.md
@@ -6,9 +6,9 @@ Nick Anderson <nick@cmdln.org>
 linux
 
 ## DESCRIPTION
-* cfdc_etc_hosts_manage_all_entries
+* configure_etc_hosts
     - edit_line based
-    - removes any entries not specified except localhost and comments
+    - optionally removes any entries not specified except localhost and comments
     - Allows single definition of each entry allowing comments for 
       knowledge management to be attached to each entry.
 
@@ -17,45 +17,15 @@ linux
 standard library
 
 ## SAMPLE USAGE
-    body common control {
-
-    }
-
-       bundlesequence  => {
-                           "main",
-                           };
-
-       inputs          => {
-                           "cfengine_stdlib.cf",
-                           "sketches/etc_hosts/etc_hosts.cf",
-                           };
-    }
-
     bundle agent main {
-       vars:
-           "hosts[192.0.2.10]"
-               string  => "mailhost.mynet.com ntp02",
-               comment => "No one should rely on DNS when resolving the mail server";
+    vars:
+        "hosts_entry[192.168.1.254]" string => "gateway.localdomain";
+        "hosts_entry[192.168.1.2]"   string => "printer";
+        "hosts_defined_only" string => "true";
 
-           "hosts[192.0.2.11]"
-               string => "ntp01.mynet.com ntp02",
-               comment => "No one should rely on DNS when resolving local time servers";
-
-           "hosts[192.0.2.12]"
-               string => "ntp02.mynet.com ntp02",
-               comment => "No one should rely on DNS when resolving local time servers";
-
-           # you can use classes to restrict which nodes would get this setting
-           am_db_node::
-               "hosts[192.0.2.20]"
-                   string  => "clusterscan.mynet.com clusterscan",
-                   comment => "DB nodes should get an entry for the db cluster so they arent
-                               relying on DNS";
-
-
-       methods:
-           "any" usebundle => cfdc_etc_hosts_manage_all_entries("main.hosts");
+    methods:
+        "etc_hosts"
+            usebundle => configure_etc_hosts("main.hosts_");
 
     }
-
 

--- a/sketches/system/etc_hosts/changelog
+++ b/sketches/system/etc_hosts/changelog
@@ -1,0 +1,4 @@
+configure_etc_hosts 2.0
+  * cfsketchify
+  * Added parameter to toggle deleting undefined entries
+  * renamed from cfdc_etc_hosts_manage_all_entries

--- a/sketches/system/etc_hosts/main.cf
+++ b/sketches/system/etc_hosts/main.cf
@@ -1,4 +1,11 @@
-bundle agent cfdc_etc_hosts_manage_all_entries(config) {
+bundle agent meta_configure_etc_hosts{
+vars:
+   "argument[entry]" string => "array";
+   "optional_argument[defined_only]" string => "string",
+        comment => "Must be true or yes to activate"; 
+
+}
+bundle agent configure_etc_hosts(prefix) {
 # Used for enforcing the complete contents of /etc/hosts
 # Warning: This is somewhat draconian, but it might be more desireable
 # than distributing a hand edited file since the definition of each element
@@ -26,7 +33,7 @@ bundle agent cfdc_etc_hosts_manage_all_entries(config) {
 #    replaced if you provide an entry for it
 #
 # If you want additional exclusions in addition to localhost and # comments see
-# the delete_lines regex in cfdc_etc_hosts_manage_all_entries_delete_nonmanaged
+# the delete_lines regex in configure_etc_hosts_delete_nonmanaged
 # Usage:
 #   body common control {
 #
@@ -65,15 +72,20 @@ bundle agent cfdc_etc_hosts_manage_all_entries(config) {
 #
 #
 #       methods:
-#           "any" usebundle => cfdc_etc_hosts_manage_all_entries("main.hosts");
+#           "any" usebundle => configure_etc_hosts("main.hosts");
 #
 #    }
-
+# "hosts_entry[ip]" string => "names";
+# "hosts_defined_only" string => "true/yes";
 
     vars:
+        "canon_prefix" string => canonify("$(prefix)");
         "ip" 
-            slist   => getindices("$(config)"),
+            slist   => getindices("$(prefix)entry"),
             comment => "We need the list of IPs to look for in the hosts file";
+
+        "config[$(ip)]"
+            string => "$($(prefix)entry[$(ip)])";
 
         "esc_ips[$(ip)]" 
             string  => escape("$(ip)"),
@@ -93,19 +105,24 @@ bundle agent cfdc_etc_hosts_manage_all_entries(config) {
                 string  => "$(sys.winsysdir)\drivers\etc\hosts",
                 comment => "Path to the systems hosts file";
 
+    classes:
+        "only_allow_defined_entries" expression => regcmp("(?i)yes|true", "$($(prefix)defined_only)");
+
     files:
         "$(hosts)"
             create      =>  "true",
-            edit_line   =>  replace_or_add("^$(esc_ips[$(ip)])\s.*", "$(ip)    $($(config)[$(ip)])"),
+            edit_line   =>  replace_or_add("^$(esc_ips[$(ip)])\s.*", "$(ip)    $(config[$(ip)])"),
             comment     =>  "Fix hosts entry to be as defined.";
 
+        # We only need to delete nonmanaged entries if we  specify the only_defined flag
         "$(hosts)"
-            edit_line   => cfdc_etc_hosts_manage_all_entries_delete_nonmanaged("@(cfdc_etc_hosts_manage_all_entries.ip)"),
+            edit_line   => configure_etc_hosts_delete_nonmanaged("@(configure_etc_hosts.ip)"),
+            ifvarclass  => "only_allow_defined_entries",
             comment     => "Delete lines that do not match our managed ip list";
 
         "$(hosts)"
             create      =>  "true",
-            edit_line   =>  cfdc_etc_hosts_manage_all_entries_prepend_if_no_line("$(CFEnotice)"),
+            edit_line   =>  configure_etc_hosts_prepend_if_no_line("$(CFEnotice)"),
             comment     =>  "Notice that the file is managed by CFEngine";
 
         # I have no idea what windows permissions should be for this file
@@ -114,9 +131,12 @@ bundle agent cfdc_etc_hosts_manage_all_entries(config) {
                 perms   => mog("644", "root", "root"),
                 comment => "Set proper permissions so everyone can read it"; 
 
+    reports:
+        debug::
+            "$(ip)    $(config[$(ip)])";
 }
 
-bundle edit_line cfdc_etc_hosts_manage_all_entries_prepend_if_no_line(string) {
+bundle edit_line configure_etc_hosts_prepend_if_no_line(string) {
     insert_lines:
     "$(string)" 
         location => start,
@@ -124,7 +144,7 @@ bundle edit_line cfdc_etc_hosts_manage_all_entries_prepend_if_no_line(string) {
 }
 
 
-bundle edit_line cfdc_etc_hosts_manage_all_entries_delete_nonmanaged(ips){
+bundle edit_line configure_etc_hosts_delete_nonmanaged(ips){
     vars:
         "regex" 
             string  => join ("|", "ips"),

--- a/sketches/system/etc_hosts/params/example.json
+++ b/sketches/system/etc_hosts/params/example.json
@@ -1,0 +1,4 @@
+{
+    "entry": { "192.168.1.254": "gateway", "192.168.1.2": "printer" },
+    "defined_only": "true",
+}

--- a/sketches/system/etc_hosts/sketch.json
+++ b/sketches/system/etc_hosts/sketch.json
@@ -1,0 +1,20 @@
+{
+
+    "manifest":
+    {
+        "main.cf": { "desc": "main file", "version": 2.0 },
+        "README.md": { "documentation": true },
+        "params/example.json": { "comment": "Example parameters" },
+    },
+
+    "metadata":
+    {
+        "name": "System::etc_hosts",
+        "version": 2.0,
+        "authors": [ "Nick Anderson <nick@cmdln.org>" ],
+        "depends": { "CFEngine::stdlib": { "version": 105 }, "cfengine": { "version": "3.2.1" }, "os": [ "linux" ] },
+    },
+
+    "entry_point": "main.cf",
+    "interface": [ "main.cf" ]
+}

--- a/sketches/system/etc_hosts/test.cf
+++ b/sketches/system/etc_hosts/test.cf
@@ -1,0 +1,22 @@
+body common control {
+
+    bundlesequence => { "main",};
+
+    inputs => {
+                "../../libraries/copbl/cfengine_stdlib.cf",
+                "./main.cf",
+              };
+}
+
+bundle agent main {
+vars:
+    "hosts_entry[192.168.1.254]" string => "gateway";
+    "hosts_entry[192.168.1.2]"   string => "printer";
+    "hosts_defined_only" string => "YeS";
+
+methods:
+    "etc_hosts"
+        usebundle => configure_etc_hosts("main.hosts_");
+
+}
+


### PR DESCRIPTION
drop cfdc prefix, make removal of non-managed entries optional via parameter and rename bundle to represent more generic behavior
