### PR TITLE
Fixed bug in --remove

### DIFF
--- a/tools/cf-sketch/cf-sketch.pl
+++ b/tools/cf-sketch/cf-sketch.pl
@@ -949,7 +949,7 @@ sub deactivate
   }
   elsif ($all_params)
   {
-   my %info = %{$activations->{$sketch}};
+   my %info = %{$activations->{$sketch}||{}};
    delete $activations->{$sketch};
    print GREEN "Deactivated: all $sketch activations (@{[ sort keys %info ]})\n"
     unless $quiet;


### PR DESCRIPTION
Was producing an error when there were no activations of the sketch to remove.
