### PR TITLE
Fix fullpath-dependent behavior

### DIFF
--- a/tools/cf-sketch/cf-sketch.pl
+++ b/tools/cf-sketch/cf-sketch.pl
@@ -594,7 +594,7 @@ sub generate
 
        # force-feed the bundle location here to work around a possible this.promise_filename bug
        $varlist->{bundle_home} = 'string';
-       $pdata->{bundle_home} = '$(sys.workdir)/inputs/sketches/' . $data->{dir};
+       $pdata->{bundle_home} = $options{fullpath} ? $data->{fulldir} : '$(sys.workdir)/inputs/sketches/' . $data->{dir};
 
        # provide the metadata that could be useful
        my @files = sort keys %{$data->{manifest}};


### PR DESCRIPTION
Fix several commands (--generate, --list, --remove) that were broken depending on the --fullpath setting.
