### PR TITLE
Fix cf-sketch install problem

### DIFF
--- a/sketches/utilities/halt_agent_if_file_exists/changelog
+++ b/sketches/utilities/halt_agent_if_file_exists/changelog
@@ -1,3 +1,5 @@
+halt_agent_if_file_exists 1.2
+  * Move meta_ bundle below main entry, cf-sketch complained during install
 halt_agent_if_file_exists 1.0
   * Add bundle to act as single interface between alert and abort bundles
   * Change public api to cf-sketch style prefix

--- a/sketches/utilities/halt_agent_if_file_exists/main.cf
+++ b/sketches/utilities/halt_agent_if_file_exists/main.cf
@@ -1,22 +1,6 @@
 # -*- mode: cfengine3; indent-tabs-mode: nil; cfengine-parameters-indent: (promise pname 2); -*-
 # vi:tabstop=2:expandtab
 
-
-bundle agent meta_cfdc_halt_agent_if_file_exists{
-  vars:
-    "argument[trigger_file]"   string => "string";
-    "argument[abort_class]"    string => "string";
-
-    # Control behavior when trigger file exists, set these to true or yes
-    "optional_argument[alert]" 
-        string => "string",
-        comment => "Must be true or yes to activate";
-
-    "optional_argument[abort]" 
-        string => "string",
-        comment => "Must be true or yes to activate";
-}
-
 bundle agent cfdc_halt_agent_if_file_exists(prefix){
   vars:
     "canon_prefix"  string => canonify("$(prefix)");
@@ -47,6 +31,21 @@ bundle agent cfdc_halt_agent_if_file_exists(prefix){
       "abort_class: $(abort_class)";
       "alert: $(alert)";
       "abort: $(abort)";
+}
+
+bundle agent meta_cfdc_halt_agent_if_file_exists{
+  vars:
+    "argument[trigger_file]"   string => "string";
+    "argument[abort_class]"    string => "string";
+
+    # Control behavior when trigger file exists, set these to true or yes
+    "optional_argument[alert]" 
+        string => "string",
+        comment => "Must be true or yes to activate";
+
+    "optional_argument[abort]" 
+        string => "string",
+        comment => "Must be true or yes to activate";
 }
 
 #

--- a/sketches/utilities/halt_agent_if_file_exists/sketch.json
+++ b/sketches/utilities/halt_agent_if_file_exists/sketch.json
@@ -2,7 +2,7 @@
 
     "manifest":
     {
-        "main.cf": { "desc": "main file", "version": 1.0 },
+        "main.cf": { "desc": "main file", "version": 1.1 },
         "README.md": { "documentation": true },
         "params/example.json": { "comment": "Example parameters" },
         "test.cf": { "comment": "Standalone test policy" },
@@ -12,7 +12,7 @@
     "metadata":
     {
         "name": "Utilities::halt_agent_if_file_exists",
-        "version": 1.1,
+        "version": 1.2,
         "license": "MIT",
         "portfolio": [ "cfdc" ],
         "authors": [ "Ben Heilman <bheilman@enova.com>", "Nick Anderson <nick@cmdln.org>" ],


### PR DESCRIPTION
cf-sketch was complaining that it could not find the meta definition.
Moving meta_ bundle below main entry resolved the error.
