### PR TITLE
Clean up colorization when cf-sketch exits in a bad mood

### DIFF
--- a/tools/cf-sketch/cf-sketch.pl
+++ b/tools/cf-sketch/cf-sketch.pl
@@ -54,6 +54,11 @@ BEGIN
     }
 }
 
+END {
+    # This prevents the blood-stained prompt after we die
+    print RESET;
+}
+
 ###### Some basic constants and settings.
 
 use constant SKETCH_DEF_FILE => 'sketch.json';


### PR DESCRIPTION
This'll reset the terminal colors so that your prompt doesn't turn red when you color_die.
