### PR TITLE
Add trigger_context

### DIFF
--- a/sketches/utilities/abortclasses/main.cf
+++ b/sketches/utilities/abortclasses/main.cf
@@ -3,7 +3,7 @@
 
 # N.B. Namespacing this sketch would make it much harder to use.  So we didn't.
 
-bundle agent abortclasses_filebased(abortclass, trigger_file, alert_only)
+bundle agent abortclasses_filebased(abortclass, trigger_file, alert_only, trigger_context)
 {
   meta:
       "vars[abortclass][type]"      string => "CONTEXT_NAME";
@@ -14,6 +14,9 @@ bundle agent abortclasses_filebased(abortclass, trigger_file, alert_only)
 
       "vars[alert_only][type]"      string => "BOOLEAN";
       "vars[alert_only][default]"   string => "0";
+
+      "vars[trigger_context][type]"    string => "CONTEXT_NAME";
+      "vars[trigger_context][default]" string => "!opt_dry_run";
 
   classes:
       "alert_only" expression => strcmp("$(alert_only)", "1");
@@ -28,12 +31,15 @@ bundle agent abortclasses_filebased(abortclass, trigger_file, alert_only)
 
     fileexists.!alert::
       "do abort"
-      usebundle  => abortclasses_abort($(abort_class)),
-      comment    => "Define $(abort_class) since file $(trigger_file) exists";
+      usebundle  => abortclasses_abort($(abortclass)),
+      ifvarclass => "$(trigger_context)",
+      comment    => "Define $(abortclass) since file $(trigger_file) exists in the context of $(trigger_context)"; 
 
   reports:
     debug::
-      "abortclasses: trigger_file: $(trigger_file), abortclass: $(abortclass), alert_only: $(alert_only)";
+      "abortclasses: trigger_file: $(trigger_file), abortclass: $(abortclass) alert_only: $(alert_only), trigger_context: $(trigger_context)";
+      "abortclasses: trigger_context: $(trigger_context) not currently defined, will not actually abort",
+        ifvarclass => "$(trigger_context)";
     debug.alert::
       "abortclasses: alert-only mode!!!";
     debug.alert_only::

--- a/sketches/utilities/abortclasses/params/example.json
+++ b/sketches/utilities/abortclasses/params/example.json
@@ -2,6 +2,7 @@
     "Utilities::abortclasses":
     {
         "trigger_file": { "bycontext": { "!test": "/COWBOY", "test": "/tmp/COWBOY" } },
+        "trigger_context": "!opt_dry_run",
         "abortclass": "cowboy",
         "alert_only": true
     }

--- a/sketches/utilities/abortclasses/sketch.json
+++ b/sketches/utilities/abortclasses/sketch.json
@@ -13,7 +13,7 @@
     {
         "name": "Utilities::abortclasses",
 	"description": "Abort execution if a certain file exists, aka 'Cowboy mode'",
-        "version": 1.3,
+        "version": 1.4,
         "license": "MIT",
         "tags": [ "cfdc" ],
         "authors": [ "Ben Heilman <bheilman@enova.com>", "Nick Anderson <nick@cmdln.org>", "Ted Zlatanov <tzz@lifelogs.com>" ],

--- a/sketches/utilities/abortclasses/test.cf
+++ b/sketches/utilities/abortclasses/test.cf
@@ -1,9 +1,13 @@
 body common control
 {
-      bundlesequence => { "cfsketch_run" };
+      bundlesequence => { "cfsketch_run", "cfsketch_after" };
       inputs => { "./main.cf" };
 }
 
+body agent control
+{
+      abortclasses => { "cowboy" };
+}
 
 bundle common cfsketch_g
 {
@@ -14,8 +18,9 @@ bundle common cfsketch_g
       "abort_trigger_file" string => "/tmp/COWBOY";
 
     any::
-      "abort_abortclass" string => "cowboy";
-      "abort_alert_only" string => "1";
+      "abort_abortclass"      string => "cowboy";
+      "abort_alert_only"      string => "0";
+      "abort_trigger_context" string => "!opt_dry_run";
 }
 
 bundle agent cfsketch_run
@@ -23,6 +28,13 @@ bundle agent cfsketch_run
   methods:
       "go" usebundle => abortclasses_filebased($(cfsketch_g.abort_abortclass),
                                                $(cfsketch_g.abort_trigger_file),
-                                               $(cfsketch_g.abort_alert_only));
+                                               $(cfsketch_g.abort_alert_only),
+                                               $(cfsketch_g.abort_trigger_context));
 
+}
+bundle agent cfsketch_after
+{
+  reports:
+    opt_dry_run::
+      "I didnt abort because I was in dry run";
 }


### PR DESCRIPTION
It's useful to run in --dry-run mode if a system has been forgotten
about in cowboy mode for some time. This defaults to not aborting when
run in dry-run mode since it won't make any changes anyway.
