### PR TITLE
cf-sketch: fix list and search commands so they do not parse sketches unnecessarily

### DIFF
--- a/tools/cf-sketch/perl-lib/DesignCenter/Repository.pm
+++ b/tools/cf-sketch/perl-lib/DesignCenter/Repository.pm
@@ -97,7 +97,7 @@ sub search {
               my $new =  DesignCenter::Sketch->new(name => $sketch,
                                                    location => $dir,
                                                   );
-              $new->load;
+              $new->load(undef, 1);
               $result->{$sketch}=$new;
               next SKETCH;
             }
@@ -375,7 +375,7 @@ sub missing_dependencies
 
     foreach my $repo (@{DesignCenter::Config->repolist})
     {
-        my $contents = CFSketch::repo_get_contents($repo);
+        my $contents = CFSketch::repo_get_contents($repo, 1);
         foreach my $dep (sort keys %tocheck)
         {
             if ($dep eq 'os' &&

--- a/tools/cf-sketch/perl-lib/DesignCenter/Sketch.pm
+++ b/tools/cf-sketch/perl-lib/DesignCenter/Sketch.pm
@@ -171,6 +171,7 @@ sub load {
 sub verify_entry_point {
   my $name = shift;
   my $data = shift;
+  use Carp qw/cluck/;
 
   my $dir       = $data->{fulldir};
   my $mft       = $data->{manifest};

--- a/tools/cf-sketch/perl-lib/DesignCenter/System.pm
+++ b/tools/cf-sketch/perl-lib/DesignCenter/System.pm
@@ -74,7 +74,7 @@ sub list
     foreach my $repo (@{DesignCenter::Config->repolist}) {
       my @sketches = $self->list_internal($repo, $terms);
 
-      my $contents = CFSketch::repo_get_contents($repo);
+      my $contents = CFSketch::repo_get_contents($repo, 1);
 
       if (!scalar @sketches) {
         return $res;
@@ -115,7 +115,7 @@ sub list_internal
     print "Looking for terms [@$terms] in cf-sketch repository [$repo]\n"
       if DesignCenter::Config->verbose;
 
-    my $contents = CFSketch::repo_get_contents($repo);
+    my $contents = CFSketch::repo_get_contents($repo, 1);
     print "Inspecting repo contents: ", DesignCenter::JSON->coder->encode($contents), "\n"
       if DesignCenter::Config->verbose;
 


### PR DESCRIPTION
Please test!!!  It works OK in my testing.
