### PR TITLE
Fix repo_clear_cache to clear all cached versions of the repo.

### DIFF
--- a/tools/cf-sketch/cf-sketch.pl
+++ b/tools/cf-sketch/cf-sketch.pl
@@ -415,8 +415,8 @@ sub get_local_repo
     }
   sub repo_clear_cache {
     my $repo = shift;
-    my $noparse = shift || 0;
-    delete $content_cache{$repo,$noparse};
+    delete $content_cache{$repo,0};
+    delete $content_cache{$repo,1};
   }
 }
 


### PR DESCRIPTION
Without this fix, the cache was not getting updated after installing and removing sketches, so the listing after one of these operations would be out of date.
