### PR TITLE
Omit cfengine_stdlib.cf from inputs in non-standalone runfile

### DIFF
--- a/tools/cf-sketch/perl-lib/DesignCenter/System.pm
+++ b/tools/cf-sketch/perl-lib/DesignCenter/System.pm
@@ -150,6 +150,9 @@ sub generate_runfile
   {
     my $self=shift;
     my $standalone = shift;
+    # If given, this parameter must be a regex that indicates which files should be
+    # omitted from the "inputs" declaration. Used to omit stdlib on the non-standalone runfile.
+    my $omit_files = shift;
     $standalone = DesignCenter::Config->standalone unless defined($standalone);
     # If a filename is given, use it as is always. If we are using the default,
     # modify it depending on $standalone
@@ -333,7 +336,9 @@ sub generate_runfile
         if DesignCenter::Config->verbose;
     }
 
-    my $includes = join ', ', map { my @p = DesignCenter::JSON::recurse_print($_); $p[0]->{value} } Util::uniq(@inputs);
+    my $includes = join ', ',
+      map { my @p = DesignCenter::JSON::recurse_print($_); $p[0]->{value} }
+        grep { !$omit_files || $_ !~ /$omit_files/ } Util::uniq(@inputs);
 
     # maybe make the run template configurable?
     my $output = make_runfile($template_activations, $includes, $standalone, $run_file);

--- a/tools/cf-sketch/perl-lib/Parser/Commands/15run_deploy.pl
+++ b/tools/cf-sketch/perl-lib/Parser/Commands/15run_deploy.pl
@@ -62,7 +62,7 @@ sub command_generate {
 }
 
 sub command_deploy {
-  my $file = DesignCenter::Config->_system->generate_runfile(0);
+  my $file = DesignCenter::Config->_system->generate_runfile(0, qr/cfengine_stdlib\.cf$/);
   Util::output(GREEN."This runfile will be automatically executed from promises.cf\n".RESET);
 }
 


### PR DESCRIPTION
As a temporary measure to avoid errors from cf-agent, cfengine_stdlib.cf is omitted from the runfile generated by "deploy", under the assumption that it will already be loaded by the main promises.cf.
