### PR TITLE
Add example policy to sketch definition

### DIFF
--- a/sketches/package_management/aptrepo/sketch.json
+++ b/sketches/package_management/aptrepo/sketch.json
@@ -4,6 +4,7 @@
     {
         "main.cf": { "desc": "main file" },
         "README.md": { "documentation": true },
+        "test.cf": { "desc": "Example Policy" },
         "params/repos.json": { }
     },
 


### PR DESCRIPTION
The test/example policy needs to be installed with a sketch as a
reference.

Closes Issue #238 
