### PR TITLE
require --installsource to be a file

### DIFF
--- a/tools/cf-sketch/cf-sketch.pl
+++ b/tools/cf-sketch/cf-sketch.pl
@@ -111,7 +111,8 @@ GetOptions(\%options,
 
 #die "$0: cf-sketch can only be used in --expert mode" unless $options{expert};
 
-die "$0: --installsource DIR must be specified" unless $options{installsource};
+die "$0: --installsource FILE must be specified" unless $options{installsource};
+die "$0: $options{installsource} is not a file" unless (-f "$options{installsource}");
 
 $options{repolist} = [ "$inputs_root/sketches" ] unless scalar @{$options{repolist}};
 $options{verbose} = 1 if $options{veryverbose};


### PR DESCRIPTION
Clarifies the following scenario:

bheilman@dc35:~$ ./design-center/tools/cf-sketch/cf-sketch.pl --veryverbose --apiconfig config.json --installsource ~/design-center/sketches/ --repolist ~/policy/promises/sketches

cf-sketch> install System::motd

> > OVERRIDING CONFIG FROM config.json
> > {"log":"STDERR","log_level":4,"recognized_sources":["~/design-center/sketches"],"repolist":["~/policy/promises/sketches"],"runfile":{"filter_inputs":[],"location":"~/policy/promises/core/dc-runfile.cf","relocate_path":"sketches","standalone":false},"vardata":"~/policy/dc-registry.json"}
> > {"dc_api_version":"0.0.1","request":{"install":[{"force":0,"sketch":"System::motd","source":"/home/bheilman/design-center","target":"/home/bheilman/policy/promises/sketches"}]}}
> > DCAPI::log3(DCAPI.pm:180): Successfully loaded vardata file /home/bheilman/policy/dc-registry.json
> > << {"api_ok":{"warnings":[],"success":false,"errors":["Sketch System::motd could not be found in source repo"],"error_tags":{"System::motd":1},"data":{},"log":[],"tags":{}}}
> > OK: Got unsuccessful result: {"success":false,"warnings":[],"errors":["Sketch System::motd could not be found in source repo"],"error_tags":{"System::motd":1},"log":[],"data":{},"tags":{}}
> > Error: Sketch System::motd could not be found in source repo
> > Error: Sketch System::motd could not be found in source repo
