### PR TITLE
use choice type in file_integrity

### DIFF
--- a/sketches/security/file_integrity/sketch.json
+++ b/sketches/security/file_integrity/sketch.json
@@ -31,7 +31,7 @@
             { type: "environment", name: "runenv" },
             { type: "metadata", name: "metadata" },
             { type: "list", name: "watch", description: "Absolute path to files or directories to watch", validation: "LIST_OF_PATH_ABSOLUTE_UNIX_OR_WINDOWS", example: "/etc or /etc/passwd" },
-            { type: "string", name: "hash_algorithm", default: "sha256", description: "Hash algorithm", validation: "HASH_ALGORITHM", example: "sha256" },
+            { type: "choice", name: "hash_algorithm", default: "sha256", description: "Hash algorithm", validation: "HASH_ALGORITHM" },
             { type: "string", name: "ifelapsed", default: "1440", description: "Time in minutes that should elapse before recheck", validation: "IFELAPSED", example: "1440" },
             { type: "return", name: "paths", },
         ],

--- a/tools/cf-sketch/constdata.conf
+++ b/tools/cf-sketch/constdata.conf
@@ -2,7 +2,15 @@
    "validations" : {
       "HASH_ALGORITHM" : {
          "description" : "Hash algorithm",
-         "valid_regex" : "^(md5|sha(1|224|256|384|512)|best)$"
+         "choice" : [
+            "md5",
+            "sha1",
+            "sha224",
+            "sha256",
+            "sha384",
+            "sha512",
+            "best"
+         ]
       },
       "HOSTNAME" : {
          "description" : "Host name",


### PR DESCRIPTION
Especially useful for DC UI.
Needs backport/cherry-pick to 3.5.x before Enterprise 3.5.1 release (after DC UI is tested and fine with it).
