### PR TITLE
Explicitely set bundle entry point for activation

### DIFF
--- a/tools/cf-sketch/perl-lib/Parser/Commands/12list.pl
+++ b/tools/cf-sketch/perl-lib/Parser/Commands/12list.pl
@@ -125,10 +125,13 @@ sub command_list_params
         {
             my @sketches = @{$found{$name}};
             my $word = (scalar(@sketches)>1 ? "Sketches" : "Sketch");
-            print RESET, GREEN, $name, RESET, ": $word ".join(", ", @sketches)."\n";
+            print RESET, GREEN, $name, RESET, ": $word ".
+             join(", ", 
+                  map { my $b = $list->{$name}->{$_}->{__bundle__} || $list->{$name}->{$_}->{CF_MP_ENTRY_POINT} || undef;
+                      "$_".($b?"($b)":"")} @sketches)."\n";
             if ($full)
             {
-                print DesignCenter::JSON::pretty_print($list->{$name},"  ", undef, undef)."\n";
+                print DesignCenter::JSON::pretty_print($list->{$name},"  ", qr(__bundle__|CF_MP_ENTRY_POINT), undef)."\n";
             }
         }
     }

--- a/tools/cf-sketch/perl-lib/Parser/Commands/13activate.pl
+++ b/tools/cf-sketch/perl-lib/Parser/Commands/13activate.pl
@@ -148,12 +148,13 @@ sub command_activate {
     $envname = $env;
   }
 
-  push @{$todo{$sketch}},{
-                          target => $Config{repolist}->[0],
-                          environment => $envname,
-                          params => [ @todoparams ],
-                          identifier => $id,
-                         };
+  my $newact = {
+                target => $Config{repolist}->[0],
+                environment => $envname,
+                params => [ @todoparams ],
+                identifier => $id,
+               };
+  push @{$todo{$sketch}}, $newact;
   if (keys %todefine) {
     Util::message("Defining parameter sets: ".join(", ", sort keys %todefine).".\n");
     ($success, $result) = main::api_interaction({define => \%todefine});

--- a/tools/cf-sketch/perl-lib/Parser/Commands/17define.pl
+++ b/tools/cf-sketch/perl-lib/Parser/Commands/17define.pl
@@ -122,12 +122,13 @@ sub interactive_config {
         return;
     }
     Util::message("Defining parameter set '$paramset' with the entered data.\n");
+    $data->{__bundle__} = $bundle;
     my ($success, $result) = main::api_interaction({define => 
                                                     {
                                                      $paramset => { $sketchname => $data },
                                                     }});
     return unless $success;
-    Util::success("Parameter set $paramset successfully defined.\n");
+    Util::success("Parameter set $paramset for bundle $bundle successfully defined.\n");
 }
 
 sub query_bundle {


### PR DESCRIPTION
Explicitly set the entry point in parameter sets, this fixes potential
confusion when more than one entry point has the same API.

Fixes https://cfengine.com/dev/issues/4048
