### PR TITLE
use SunOS not solaris

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 
 UNAME := $(shell uname)
 
-ifeq ($(UNAME), Solaris)
+ifeq ($(UNAME), SunOS)
 I:=/usr/local/bin/install
 else
 I:=/usr/bin/install

--- a/tools/cf-sketch/Makefile
+++ b/tools/cf-sketch/Makefile
@@ -11,7 +11,7 @@ LIB:=$(PREFIX)/lib/cf-sketch
 
 UNAME := $(shell uname)
 
-ifeq ($(UNAME), Solaris)
+ifeq ($(UNAME), SunOS)
 I:=/usr/local/bin/install
 else
 I:=/usr/bin/install


### PR DESCRIPTION
This provides the correct detection of Solaris as the build platform / corrected from "solaris" to SunOS
