### PR TITLE
Add attribute_name to role tags for Enterprise inventory reports

### DIFF
--- a/sketches/utilities/roles/main.cf
+++ b/sketches/utilities/roles/main.cf
@@ -2,8 +2,15 @@ bundle agent roles(runenv, metadata, role, extra_roles)
 {
 #@include "REPO/sketch_template/standard.inc"
   classes:
-    "$(role)" scope => "namespace", expression => "any", meta => { "inventory" };
-    "$(extra_roles)" scope => "namespace", expression => "any", meta => { "inventory" };
+    "$(role)"
+      scope => "namespace",
+      expression => "any",
+      meta => { "inventory", "attribute_name=Role"};
+
+    "$(extra_roles)"
+      scope => "namespace",
+      expression => "any",
+      meta => { "inventory", "attribute_name=Role" };
 
   reports:
     inform_mode|dc_verbose::


### PR DESCRIPTION
This allows it to be easily picked from the dropdown in the inventory UI.
