### PR TITLE
Remove testing code (dc_test, not_test, exec_prefix, path_prefix)

### DIFF
--- a/sketches/applications/newrelic/main.cf
+++ b/sketches/applications/newrelic/main.cf
@@ -69,7 +69,7 @@ bundle agent prep
 
   files:
     debian||ubuntu::
-      "$(server.path_prefix)/etc/apt/sources.list.d/newrelic.list"
+      "/etc/apt/sources.list.d/newrelic.list"
       create => "true",
       edit_defaults => default:no_backup,
       classes => default:if_repaired("newrelic_apt_update"),
@@ -77,8 +77,8 @@ bundle agent prep
 
   commands:
     redhat.repo_not_installed::
-      "$(server.exec_prefix)$(default:paths.rpm) -Uvh http://yum.newrelic.com/pub/newrelic/el5/x86_64/newrelic-repo-5-3.noarch.rpm";
-    not_test.newrelic_apt_update::
+      "$(default:paths.rpm) -Uvh http://yum.newrelic.com/pub/newrelic/el5/x86_64/newrelic-repo-5-3.noarch.rpm";
+    newrelic_apt_update::
       "$(default:debian_knowledge.call_apt_get) update";
 }
 
@@ -91,45 +91,37 @@ bundle agent install
       contain => default:in_shell;
 
   methods:
-    not_test::
       "install" usebundle => default:package_latest("newrelic-sysmond"),
       classes => default:if_ok("newrelic_installed");
 
   reports:
     dc_verbose.newrelic_installed::
       "$(this.bundle): Installed New Relic successfully.";
-    dc_verbose.not_test.!newrelic_installed::
+    dc_verbose.!newrelic_installed::
       "$(this.bundle): Could not install New Relic successfully.";
 
     newrelic_installed::
       "1" bundle_return_value_index => "package_status";
-    not_test.!newrelic_installed::
+    !newrelic_installed::
       "0" bundle_return_value_index => "package_status";
-    dc_test::
-      "$(this.bundle): Overriding bundle return status to success (1) in test mode";
-      "1" bundle_return_value_index => "package_status";
 }
 
 bundle agent uninstall
 {
   methods:
-    not_test::
       "install" usebundle => default:package_absent("newrelic-sysmond"),
       classes => default:if_ok("newrelic_uninstalled");
 
   reports:
     dc_verbose.newrelic_uninstalled::
       "$(this.bundle): Uninstalled New Relic successfully.";
-    dc_verbose.not_test.!newrelic_uninstalled::
+    dc_verbose.!newrelic_uninstalled::
       "$(this.bundle): Could not uninstall New Relic successfully.";
 
     newrelic_uninstalled::
       "0" bundle_return_value_index => "package_status";
-    not_test.!newrelic_uninstalled::
+    !newrelic_uninstalled::
       "1" bundle_return_value_index => "package_status";
-    dc_test::
-      "$(this.bundle): Overriding bundle return status to success (0, since it uninstalls!) in test mode";
-      "0" bundle_return_value_index => "package_status";
 }
 
 bundle agent conf(runenv, metadata, pkg_status, license_key)
@@ -139,22 +131,19 @@ bundle agent conf(runenv, metadata, pkg_status, license_key)
 
   commands:
     newrelic_installed::
-      "$(server.exec_prefix)/usr/sbin/nrsysmond-config --set license_key=$(license_key)"
+      "/usr/sbin/nrsysmond-config --set license_key=$(license_key)"
       classes => default:if_ok("newrelic_configured");
 
   reports:
     dc_verbose.newrelic_configured::
       "$(this.bundle): Configured New Relic successfully.";
-    dc_verbose.not_test.!newrelic_configured::
+    dc_verbose.!newrelic_configured::
       "$(this.bundle): Could not configure New Relic successfully.";
 
     newrelic_configured::
       "1" bundle_return_value_index => "configure_status";
-    not_test.!newrelic_configured::
+    !newrelic_configured::
       "0" bundle_return_value_index => "configure_status";
-    dc_test::
-      "$(this.bundle): Overriding bundle return status to success (1) in test mode";
-      "1" bundle_return_value_index => "configure_status";
 }
 
 bundle agent proc
@@ -164,8 +153,8 @@ bundle agent proc
       restart_class => "proc_start";
 
   commands:
-    not_test.proc_start::
-      "$(server.exec_prefix)/etc/init.d/newrelic-sysmond start";
+    proc_start::
+      "/etc/init.d/newrelic-sysmond start";
 }
 
 
@@ -176,12 +165,9 @@ bundle agent proc_check
       restart_class => "proc_exists";
 
   reports:
-    dc_verbose.dc_test::
-      "$(this.bundle): Simulating ensuring New Relic successfully.";
-
-    proc_exists||dc_test::
+    proc_exists::
       "1" bundle_return_value_index => "process_status";
-    not_test.!proc_exists::
+    !proc_exists::
       "0" bundle_return_value_index => "process_status";
 }
 
@@ -189,7 +175,7 @@ bundle agent stop
 {
   processes:
       "nrsysmond"
-      process_stop => "$(server.exec_prefix)/etc/init.d/newrelic-sysmond stop";
+      process_stop => "/etc/init.d/newrelic-sysmond stop";
 }
 
 bundle agent stop_check
@@ -199,11 +185,8 @@ bundle agent stop_check
       restart_class => "proc_exists";
 
   reports:
-    dc_verbose.dc_test::
-      "$(this.bundle): Simulating stopping New Relic successfully.";
-
-    !proc_exists||dc_test::
+    !proc_exists::
       "1" bundle_return_value_index => "process_status";
-    not_test.proc_exists::
+    proc_exists::
       "0" bundle_return_value_index => "process_status";
 }

--- a/sketches/applications/splunk/main.cf
+++ b/sketches/applications/splunk/main.cf
@@ -17,7 +17,7 @@ bundle agent install_forwarder(runenv, metadata, installdir, server, password, c
   vars:
       "return" slist => { "installed", "enabled", "configured", "restarted" };
 
-      "splunkforwarder_control" string => "$(exec_prefix)$(installdir)/bin/splunk";
+      "splunkforwarder_control" string => "$(installdir)/bin/splunk";
 
   processes:
     any::
@@ -46,7 +46,7 @@ bundle agent install_forwarder(runenv, metadata, installdir, server, password, c
 
   commands:
     !splunkforwarder_installed::
-      "$(exec_prefix)/bin/false" -> { "Mission Portal Design Center UI" }
+      "/bin/false" -> { "Mission Portal Design Center UI" }
         comment => "Since this sketch does not handle installing
                    splunkforwarder we must have a promise fail if its not present for Mission
                    Portal to detect the sketch is failing.";

--- a/sketches/networking/ntp/client/main.cf
+++ b/sketches/networking/ntp/client/main.cf
@@ -3,13 +3,9 @@ body file control
       namespace => "cfdc_ntp";
 }
 
-bundle agent client(runenv,metadata,peers,servers,restrictions,driftfile,given_statsdir,given_conffile)
+bundle agent client(runenv,metadata,peers,servers,restrictions,driftfile,statsdir,conffile)
 {
 #@include "REPO/sketch_template/standard.inc"
-
-  vars:
-      "conffile" string => "$(path_prefix)$(given_conffile)";
-      "statsdir" string => "$(path_prefix)$(given_statsdir)";
 
   methods:
       "NTP CLIENT INSTALL $(runenv)"
@@ -38,25 +34,19 @@ bundle agent client(runenv,metadata,peers,servers,restrictions,driftfile,given_s
 bundle agent install
 {
   methods:
-    not_test::
       "ntp" usebundle => cfe_package_ensure("ntp", "add"),
       classes => default:if_ok("ntp_client_installed");
 
   reports:
-    dc_verbose.dc_test.ntp_client_installed::
-      "$(client.dcbundle): Simulated the installation of NTP successfully.";
-    dc_verbose.not_test.ntp_client_installed::
+    dc_verbose.ntp_client_installed::
       "$(client.dcbundle): Installed NTP successfully.";
-    dc_verbose.not_test.!ntp_client_installed::
+    dc_verbose.!ntp_client_installed::
       "$(client.dcbundle): Could not install NTP successfully.";
 
     ntp_client_installed::
       "1" bundle_return_value_index => "package_status";
-    not_test.!ntp_client_installed::
+    !ntp_client_installed::
       "0" bundle_return_value_index => "package_status";
-    dc_test::
-      "$(client.dcbundle): Overriding bundle return status to success (1) in test mode";
-      "1" bundle_return_value_index => "package_status";
 }
 
 bundle agent conf(runenv,metadata,pkg_status,peers,servers,restrictions,driftfile,statsdir,conffile)
@@ -105,13 +95,13 @@ bundle agent proc(service_mode)
 
   commands:
     ntp_client_conf_repaired.(redhat|centos|fedora)::
-      "$(client.exec_prefix)/etc/init.d/ntpd restart";
+      "/etc/init.d/ntpd restart";
     ntp_client_conf_repaired.(ubuntu|debian)::
-      "$(client.exec_prefix)/etc/init.d/ntp restart";
+      "/etc/init.d/ntp restart";
     ntp_client_proc_start.(redhat|centos|fedora)::
-      "$(client.exec_prefix)/etc/init.d/ntpd start";
+      "/etc/init.d/ntpd start";
     ntp_client_proc_start.(ubuntu|debian)::
-      "$(client.exec_prefix)/etc/init.d/ntp start";
+      "/etc/init.d/ntp start";
 }
 
 bundle edit_line ntp_client_editline(peers,servers,restrictions,driftfile,statsdir)

--- a/sketches/package_management/packages_installed/main.cf
+++ b/sketches/package_management/packages_installed/main.cf
@@ -10,14 +10,10 @@ bundle agent from_list(runenv, metadata, pkgs_add, state)
     "latest_wanted" expression => strcmp("addupdate", $(state));
 
   methods:
-    not_test.latest_wanted::
+    latest_wanted::
       "install" usebundle => default:package_latest($(pkgs_add));
-    not_test.!latest_wanted::
+    !latest_wanted::
       "install" usebundle => default:package_present($(pkgs_add));
-
-  reports:
-    dc_test::
-      "$(dcbundle): In test mode, simulating adding package $(pkgs_add)";
 }
 
 bundle agent from_file(runenv, metadata, file, state)
@@ -30,14 +26,12 @@ bundle agent from_file(runenv, metadata, file, state)
       "have_todo" expression => isvariable("todo");
 
   methods:
-    have_todo.not_test.latest_wanted::
+    have_todo.latest_wanted::
       "install" usebundle => default:package_latest($(todo));
-    have_todo.not_test.!latest_wanted::
+    have_todo.!latest_wanted::
       "install" usebundle => default:package_present($(todo));
 
   reports:
-    have_todo.dc_test::
-      "$(dcbundle): In test mode, simulating adding package $(todo)";
     !have_todo::
       "$(dcbundle): file $(file) could not be parsed to get the file list";
 }
@@ -54,18 +48,15 @@ bundle agent from_url(runenv, metadata, url, state, retriever, spooldir)
       "have_file" expression => fileexists($(spoolfile));
 
   commands:
-    have_exec_prefix::
-      "$(exec_prefix)$(retriever) > $(spoolfile)"
+      "$(retriever) > $(spoolfile)"
       contain => default:in_shell,
       classes => default:scoped_classes_generic("retrieve", "bundle");
 
   methods:
-    not_test.have_file::
+    have_file::
       "install" usebundle => default:package_specific($(spoolfile), $(state), "0.0.0", "*");
 
   reports:
-    have_file.dc_test::
-      "$(dcbundle): In test mode, simulating adding package $(spoolfile)";
     !have_file.retrieve_reached::
       "$(dcbundle): file $(spoolfile) could not be retrieved from $(url)";
 }

--- a/sketches/package_management/packages_removed/main.cf
+++ b/sketches/package_management/packages_removed/main.cf
@@ -8,12 +8,7 @@ bundle agent removed(runenv, metadata, pkgs_removed)
 #@include "REPO/sketch_template/standard.inc"
 
   methods:
-    not_test::
       "install" usebundle => default:package_absent($(pkgs_removed));
-
-  reports:
-    dc_test::
-      "$(dcbundle): In test mode, simulating removing package $(pkgs_removed)";
 }
 
 bundle agent remove_from_file(runenv, metadata, file)
@@ -26,12 +21,10 @@ bundle agent remove_from_file(runenv, metadata, file)
       "have_todo" expression => isvariable("todo");
 
   methods:
-    have_todo.not_test::
+    have_todo::
       "install" usebundle => default:package_absent($(todo));
 
   reports:
-    have_todo.dc_test::
-      "$(dcbundle): In test mode, simulating removing package $(todo)";
     !have_todo::
       "$(dcbundle): file $(file) could not be parsed to get the file list";
 }

--- a/sketches/primitives/file_existence/main.cf
+++ b/sketches/primitives/file_existence/main.cf
@@ -48,7 +48,6 @@ bundle agent present(runenv, metadata, list_of_files, success_class, fail_class)
 #@include "REPO/sketch_template/standard.inc"
 
   files:
-    not_test::
       "$(list_of_files)"
       create => "true",
       classes => default:scoped_classes_generic("bundle", $(list_of_files));
@@ -86,7 +85,6 @@ bundle agent absent(runenv, metadata, list_of_files, success_class, fail_class)
 #@include "REPO/sketch_template/standard.inc"
 
   files:
-    not_test::
       "$(list_of_files)"
       delete => default:tidy;
 

--- a/sketches/security/file_integrity/main.cf
+++ b/sketches/security/file_integrity/main.cf
@@ -3,17 +3,11 @@ body file control
       namespace => "cfdc_file_integrity";
 }
 
-bundle agent watch(runenv, metadata, given_watch, hash_algorithm, ifelapsed)
+bundle agent watch(runenv, metadata, watch, hash_algorithm, ifelapsed)
 {
 #@include "REPO/sketch_template/standard.inc"
 
   vars:
-    dc_test::
-      "watch" slist => { "/tmp" }, policy => "free";
-    not_test::
-      "watch" slist => { @(given_watch) }, policy => "free";
-
-    any::
       "watch_str" string => join(";", watch), policy => "free";
 
   files:
@@ -24,7 +18,6 @@ bundle agent watch(runenv, metadata, given_watch, hash_algorithm, ifelapsed)
       action       => default:if_elapsed($(ifelapsed));
 
   reports:
-    any::
       "$(watch_str)" bundle_return_value_index => "paths";
 }
 

--- a/sketches/security/nologin/main.cf
+++ b/sketches/security/nologin/main.cf
@@ -8,15 +8,14 @@ bundle agent localuser_nologin(runenv, metadata, list_of_users)
 #@include "REPO/sketch_template/standard.inc"
 
   vars:
-      "nologin_bin" string => "$(exec_prefix)$(default:paths.path[nologin])";
+      "nologin_bin" string => "$(default:paths.path[nologin])";
 
   classes:
       "state_nologin"
       expression => strcmp( $(state), "nologin" ),
       scope => "namespace";
 
-      "have_nologin"
-      or => { "dc_test", isexecutable("$(nologin_bin)") };
+      "have_nologin" expression => isexecutable("$(nologin_bin)");
 
       "have_$(list_of_users)" expression => userexists("$(list_of_users)");
 
@@ -47,7 +46,7 @@ bundle agent etc_nologin(runenv, metadata, state, content)
 #@include "REPO/sketch_template/standard.inc"
 
   vars:
-      "etc_nologin" string => "$(path_prefix)/etc/nologin";
+      "etc_nologin" string => "/etc/nologin";
       "valid_states" slist => { "present", "absent" }; # Same as choices in the sketch.metadata file. Its good to verify everywhere! Expect bad params!
 
   classes:

--- a/sketches/sketch_template/standard.inc
+++ b/sketches/sketch_template/standard.inc
@@ -10,27 +10,15 @@
       # canon_prefix will give you that.
       "canon_prefix" string => canonify("$(prefix)");
       "dcbundle" string => concat("[$(metadata[name])] ", $(this.namespace), ':', $(this.bundle));
-      "prefixes" slist => { "show", "exec", "path" };
 
     dc_verbose::
       # pretty-print the authors and dependencies
       "dependencies" string => format("%S", "metadata[depends]");
       "authors" string => format("%S", "metadata[authors]");
 
-    not_test::
-      "exec_prefix" string => "", policy => "free";
-      "show_prefix" string => "", policy => "free";
-      "path_prefix" string => "", policy => "free";
-
-    dc_test::
-      "exec_prefix" string => "$(default:paths.echo) ", policy => "free";
-      "show_prefix" string => "$(default:paths.grep) . ", policy => "free";
-      "path_prefix" string => "/tmp", policy => "free";
-
   classes:
       "dc_$(vars)" expression => "$($(vars))";
       "not_$(vars)" not => "$($(vars))";
-      "have_$(prefixes)_prefix" expression => isvariable("$(prefixes)_prefix");
 
   reports:
     dc_verbose::
@@ -43,15 +31,9 @@
       "$(dcbundle): imported environment class '$(vars)' because '$($(vars))' was true"
       ifvarclass => "dc_$(vars)";
 
-      "$(dcbundle): the $(prefixes)_prefix is '$($(prefixes)_prefix)'"
-      ifvarclass => "have_$(prefixes)_prefix";
-
     dc_verbose::
       # use the "dc_verbose" context to show the sketch operation (for the user)
       "$(dcbundle): running in verbose mode";
-    dc_test::
-       # use the "dc_test" context to help debug the sketch (for the developer)
-       "$(dcbundle): running in test mode";
 
 ##############################################################################
 ## end of template                                                          ##

--- a/sketches/sketch_template/zmain.cf
+++ b/sketches/sketch_template/zmain.cf
@@ -8,10 +8,9 @@ bundle agent entry(runenv, metadata, prefix, myboolean, mytype, myip, mylist, my
 #@include "standard.inc"
   vars:
       # call the sample.sh script
-      "sample_return" string => execresult(concat($(exec_prefix),
-                                                  $(this.promise_dirname),
-                                                  "/scripts/sample.sh"),
-                                           "useshell");
+      "sample_return" string => execresult(concat($(this.promise_dirname),
+                                                 "/scripts/sample.sh"),
+                                          "useshell");
 
       "mylist_str" string => format("%S", mylist);
       "myarray_str" string => format("%S", myarray);

--- a/sketches/system/config_resolver/main.cf
+++ b/sketches/system/config_resolver/main.cf
@@ -7,10 +7,8 @@ bundle agent resolver(runenv, metadata, file, nameserver, search, domain, option
 {
 #@include "REPO/sketch_template/standard.inc"
 
-  vars:
-      "rfile" string => "$(path_prefix)$(file)";
   files:
-      "$(rfile)"
+      "$(file)"
       handle        => "cfdc_config_resolver_file",
       create        => "true",
       edit_defaults => default:empty,
@@ -22,11 +20,11 @@ bundle agent resolver(runenv, metadata, file, nameserver, search, domain, option
                                                    @(sortlist),
                                                    @(extra)),
       classes       => default:if_ok("resolver_edit_successful"),
-      comment       => "Empty and edit resolver file $(rfile)";
+      comment       => "Empty and edit resolver file $(file)";
 
   reports:
     resolver_edit_successful::
-      "$(rfile)" bundle_return_value_index => "resolv_conf";
+      "$(file)" bundle_return_value_index => "resolv_conf";
     !resolver_edit_successful::
       "" bundle_return_value_index => "resolv_conf";
 }

--- a/sketches/system/etc_hosts/main.cf
+++ b/sketches/system/etc_hosts/main.cf
@@ -29,7 +29,7 @@ body file control
 # 3. Any line beginning with ::1 will never be deleted by this bundle, only
 #    replaced if you provide an entry for it
 
-bundle agent configure(runenv, metadata, original_hostfile, defined_only, hosts)
+bundle agent configure(runenv, metadata, hostfile, defined_only, hosts)
 {
 #@include "REPO/sketch_template/standard.inc"
 
@@ -40,15 +40,10 @@ bundle agent configure(runenv, metadata, original_hostfile, defined_only, hosts)
       "CFEnotice" string  => "# This file is managed by CFEngine, manual edits will be reverted",
       comment => "It's nice to let people know why the file keep magically reverting on them";
 
-      "class_prefix" string => canonify($(hostfile));
-
-      "hostfile" string => "$(path_prefix)$(original_hostfile)";
-
   classes:
       "defined_only" expression => strcmp($(defined_only), "1");
 
   files:
-    have_path_prefix::
       "$(hostfile)"
       create      =>  "true",
       edit_line   =>  default:set_line_based("cfdc_etc_hosts:configure.hosts",
@@ -66,22 +61,21 @@ bundle agent configure(runenv, metadata, original_hostfile, defined_only, hosts)
       edit_line   => delete_nonmanaged("@(configure.ip)"),
       comment     => "Delete lines that do not match our managed ip list";
 
-    have_path_prefix::
       "$(hostfile)"
       create      =>  "true",
       edit_line   =>  default:prepend_if_no_line("$(CFEnotice)"),
       comment     =>  "Notice that the file is managed by CFEngine";
 
       # I have no idea what windows permissions should be for this file
-    !windows.not_test::
+    !windows::
       "$(hostfile)"
       perms   => default:mog("644", "root", "root"),
       comment => "Set proper permissions so everyone can read it";
 
   reports:
-    dc_verbose.have_path_prefix.defined_only::
+    dc_verbose.defined_only::
       "$(dcbundle): only the defined hosts will be left in $(hostfile)";
-    dc_verbose.have_path_prefix.!defined_only::
+    dc_verbose.!defined_only::
       "$(dcbundle): the defined hosts will be added to $(hostfile)";
 
     dc_verbose::

--- a/sketches/system/motd/main.cf
+++ b/sketches/system/motd/main.cf
@@ -9,19 +9,16 @@ bundle agent entry(runenv, metadata, motd, motd_path, prepend_command, symlink_p
 
   vars:
     dc_activated::
-      "owner" string => ifelse("dc_test", $(this.promiser_uid),
-                               "root"),
+      "owner" string => "root",
       comment => "Owner of the MotD file";
 
-    have_path_prefix::
-      "path" string => "$(path_prefix)$(motd_path)",
+      "path" string => $(motd_path),
       comment => "Path of the main MotD";
 
-      "symlink" string => "$(path_prefix)$(symlink_path)";
+      "symlink" string => $(symlink_path);
 
     prepend_command_given::
-      "output" string => execresult("$(exec_prefix)$(prepend_command)",
-                                    "useshell");
+      "output" string => execresult($(prepend_command), "useshell");
 
       "main_lines" slist => { $(output), $(motd) },
       policy => "free",
@@ -40,7 +37,7 @@ bundle agent entry(runenv, metadata, motd, motd_path, prepend_command, symlink_p
       "create_symlink" not => strcmp($(symlink_path),"");
 
   files:
-    have_path_prefix.dc_activated::
+    dc_activated::
       "$(path)"
       pathtype => "literal",
       create => "true",
@@ -50,7 +47,7 @@ bundle agent entry(runenv, metadata, motd, motd_path, prepend_command, symlink_p
       perms => default:mog("444",$(owner),$(owner)),
       comment => "Create and populate the static motd file";
 
-    have_path_prefix.create_symlink::
+    create_symlink::
       "$(symlink)"
       pathtype => "literal",
       move_obstructions => "true",
@@ -58,7 +55,7 @@ bundle agent entry(runenv, metadata, motd, motd_path, prepend_command, symlink_p
       comment => "create a symlink to the motd file";
 
   reports:
-    have_path_prefix.dc_verbose::
+    dc_verbose::
       "$(dcbundle): owner = $(owner)";
       "$(dcbundle): output = '$(output)'" ifvarclass => "prepend_command_given";
       "$(dcbundle): path = $(path)";

--- a/sketches/system/set_hostname/main.cf
+++ b/sketches/system/set_hostname/main.cf
@@ -30,7 +30,7 @@ bundle agent set(runenv, metadata, hostname, domainname)
 
   files:
     debian::
-      "$(path_prefix)/etc/hostname"
+      "/etc/hostname"
       comment => "Set host-name, not FQDN in this file - in accordance with man 1 hostname",
       handle => "cfdc_hostname_set_debian",
       create => "true",
@@ -40,7 +40,7 @@ bundle agent set(runenv, metadata, hostname, domainname)
       classes => default:if_repaired("set_hostname_update");
 
     redhat::
-      "$(path_prefix)/etc/sysconfig/network"
+      "/etc/sysconfig/network"
       create => "true",
       handle => "cfdc_hostname_set_redhat",
       perms => default:mog("644", "root", "root"),
@@ -55,7 +55,7 @@ I have been doing it wrong for years, and it only
 recently bit me.";
 
     darwin::
-      "$(path_prefix)/etc/defaultdomain"
+      "/etc/defaultdomain"
       create => "true",
       edit_defaults => default:empty,
       perms => default:mog("644", "root", "root"),
@@ -64,14 +64,14 @@ recently bit me.";
       handle => "cfdc_hostname_set_darwin";
 
     gentoo::
-      "$(path_prefix)/etc/conf.d/hostname"
+      "/etc/conf.d/hostname"
       create => "true",
       perms => default:mog("644", "root", "root"),
       edit_line => default:set_variable_values("cfdc_hostname:set.confdhostname"),
       classes => default:if_repaired("set_hostname_updatehostname"),
       handle => "cfdc_hostname_set_domainname_gentoo";
 
-      "$(path_prefix)/etc/conf.d/net"
+      "/etc/conf.d/net"
       create => "true",
       perms => default:mog("644", "root", "root"),
       edit_line => default:set_variable_values("cfdc_hostname:set.confdnet"),
@@ -80,19 +80,19 @@ recently bit me.";
 
   commands:
     darwin::
-      "$(exec_prefix)/usr/sbin/scutil --set HostName $(hostname)"
+      "/usr/sbin/scutil --set HostName $(hostname)"
       classes => default:if_repaired("set_hostname_updatehostname"),
       handle => "cfdc_hostname_set_scutil_darwin";
 
     redhat||darwin||gentoo||debian::
-      "$(exec_prefix)$(sethost_command) $(hostname)"
+      "$(sethost_command) $(hostname)"
       ifvarclass => "set_hostname_update||set_hostname_updatehostname",
       comment => "Update the hostname on the running system so we
 dont have to wait for a reboot",
       handle => "cfdc_hostname_set_hostname_command";
 
     redhat||darwin||gentoo::
-      "$(exec_prefix)$(setdomain_command) $(domainname)"
+      "$(setdomain_command) $(domainname)"
       ifvarclass => "set_hostname_update||set_hostname_updatedomain",
       comment => "Update the domainname on the running system so
 we dont have to reboot for it",

--- a/sketches/system/sysctl/main.cf
+++ b/sketches/system/sysctl/main.cf
@@ -3,12 +3,13 @@ body file control
       namespace => "cfdc_sysctl";
 }
 
-bundle agent set(runenv, metadata, given_sysctl_file, empty_first, ensured_kv, removed_kv, removed_vars)
+bundle agent set(runenv, metadata, sysctl_file, empty_first, ensured_kv, removed_kv, removed_vars)
 {
 #@include "REPO/sketch_template/standard.inc"
   vars:
       "sysctl_vars" slist => getindices(ensured_kv);
       "removed_kvindices" slist => getindices(removed_kv);
+      "sysctl_run" string => "$(default:paths.path[sysctl])";
 
       # build the array of things to be removed
       "removed[$(removed_vars)]"  string => ".*";
@@ -16,11 +17,6 @@ bundle agent set(runenv, metadata, given_sysctl_file, empty_first, ensured_kv, r
 
     second_class_pass::
       "removed_indices" slist => { getindices("cfdc_sysctl:set.removed") };
-
-    have_path_prefix::
-      "sysctl_file" string => "$(path_prefix)$(given_sysctl_file)";
-    have_exec_prefix::
-      "sysctl_run" string => "$(exec_prefix)$(default:paths.path[sysctl])";
 
   classes:
       # We need to know if we are on the second pass
@@ -31,7 +27,7 @@ bundle agent set(runenv, metadata, given_sysctl_file, empty_first, ensured_kv, r
       "have_removed_indices" expression => isvariable("removed_indices");
 
   files:
-    have_path_prefix.!empty_first::
+    !empty_first::
       "$(sysctl_file)"
       create => "true",
       handle => "sysctl_files_noempty",
@@ -39,7 +35,7 @@ bundle agent set(runenv, metadata, given_sysctl_file, empty_first, ensured_kv, r
       classes => default:if_repaired("sysctl_reload"),
       comment => "Only ensure specific defined values are present";
 
-    have_path_prefix.empty_first::
+    empty_first::
       "$(sysctl_file)"
       create => "true",
       handle => "sysctl_files_empty_first",
@@ -49,7 +45,7 @@ bundle agent set(runenv, metadata, given_sysctl_file, empty_first, ensured_kv, r
       comment => "Empty file before ensuring specified values are present,
 this effectively promises the full file content.";
 
-    have_removed_indices.have_path_prefix::
+    have_removed_indices::
       "$(sysctl_file)"
       create => "true",
       edit_line => cfdc_sysctl:del_variable_values("cfdc_sysctl:set.removed"),
@@ -57,7 +53,6 @@ this effectively promises the full file content.";
       comment => "Ensure the variables and values given do not exist at all.";
 
   commands:
-    have_exec_prefix::
       "$(sysctl_run)"
       args => "-p",
       classes => default:if_repaired("sysctl_reloaded"),
@@ -67,7 +62,7 @@ this effectively promises the full file content.";
     any::
       "$(sysctl_file)" bundle_return_value_index => "sysctl_file";
 
-    have_path_prefix.dc_verbose.empty_first::
+    dc_verbose.empty_first::
       "$(dcbundle): $(sysctl_file) will be emptied before editing";
 
     second_class_pass.dc_verbose::
@@ -77,7 +72,7 @@ this effectively promises the full file content.";
     have_removed_indices.dc_verbose::
       "$(dcbundle): Remove sysctl var: $(removed_indices)=$(cfdc_sysctl:set.removed[$(removed_indices)])";
 
-    have_path_prefix.have_exec_prefix.dc_verbose::
+    dc_verbose::
       "$(dcbundle): $(sysctl_file) was not repaired, sysctl does NOT need to be reloaded with '$(sysctl_run)'"
       ifvarclass => "!sysctl_reload";
 

--- a/sketches/system/syslog/main.cf
+++ b/sketches/system/syslog/main.cf
@@ -3,7 +3,7 @@ body file control
       namespace => "cfdc_syslog";
 }
 
-bundle agent set(runenv, metadata, given_syslog_file, empty_first, ensured_kv, removed_kv, removed_vars)
+bundle agent set(runenv, metadata, syslog_file, empty_first, ensured_kv, removed_kv, removed_vars)
 {
 #@include "REPO/sketch_template/standard.inc"
 
@@ -19,9 +19,6 @@ bundle agent set(runenv, metadata, given_syslog_file, empty_first, ensured_kv, r
     second_class_pass::
       "removed_indices" slist => { getindices("cfdc_syslog:set.removed") };
 
-    have_path_prefix::
-      "syslog_file" string => "$(path_prefix)$(given_syslog_file)";
-
   classes:
       # We need to know if we are on the second pass
       "second_class_pass" and => {"first_class_pass"};
@@ -31,7 +28,7 @@ bundle agent set(runenv, metadata, given_syslog_file, empty_first, ensured_kv, r
       "have_removed_indices" expression => isvariable("removed_indices");
 
   files:
-    have_path_prefix.!empty_first::
+    !empty_first::
       "$(syslog_file)"
       create => "true",
       handle => "syslog_files_noempty",
@@ -39,7 +36,7 @@ bundle agent set(runenv, metadata, given_syslog_file, empty_first, ensured_kv, r
       classes => default:if_repaired("syslog_reload"),
       comment => "Only ensure specific defined values are present";
 
-    have_path_prefix.empty_first::
+    empty_first::
       "$(syslog_file)"
       create => "true",
       handle => "syslog_files_empty_first",
@@ -49,7 +46,7 @@ bundle agent set(runenv, metadata, given_syslog_file, empty_first, ensured_kv, r
       comment => "Empty file before ensuring specified values are present,
 this effectively promises the full file content.";
 
-    have_removed_indices.have_path_prefix::
+    have_removed_indices::
       "$(syslog_file)"
       create => "true",
       edit_line => cfdc_syslog:del_syslog_values("cfdc_syslog:set.removed"),
@@ -57,15 +54,15 @@ this effectively promises the full file content.";
       comment => "Ensure the variables and values given do not exist at all.";
 
   commands:
-    have_exec_prefix.syslog_reload.(sunos_5_8|sunos_5_9)::
-      "$(exec_prefix)/etc/init.d/syslog stop && $(exec_prefix)/etc/init.d/syslog start"
+    syslog_reload.(sunos_5_8|sunos_5_9)::
+      "/etc/init.d/syslog stop && /etc/init.d/syslog start"
       contain => default:in_shell;
-    have_exec_prefix.syslog_reload.(sunos_5_10|sunos_5_11)::
-      "$(exec_prefix)/usr/sbin/svcadm restart svc:/network/ntp:default";
-    have_exec_prefix.syslog_proc_start.(sunos_5_8|sunos_5_9)::
-      "$(exec_prefix)/etc/init.d/syslog start";
-    have_exec_prefix.syslog_proc_start.(sunos_5_10|sunos_5_11)::
-      "$(exec_prefix)/usr/sbin/svcadm enable svc:/network/ntp:default";
+    syslog_reload.(sunos_5_10|sunos_5_11)::
+      "/usr/sbin/svcadm restart svc:/network/ntp:default";
+    syslog_proc_start.(sunos_5_8|sunos_5_9)::
+      "/etc/init.d/syslog start";
+    syslog_proc_start.(sunos_5_10|sunos_5_11)::
+      "/usr/sbin/svcadm enable svc:/network/ntp:default";
 
   services:
     syslog_reload.linux::
@@ -76,10 +73,9 @@ this effectively promises the full file content.";
       comment => "Reload syslog after repairing configuration";
 
   reports:
-    have_path_prefix::
       "$(syslog_file)" bundle_return_value_index => "syslog_file";
 
-    have_path_prefix.dc_verbose.empty_first::
+    dc_verbose.empty_first::
       "$(this.bundle): $(syslog_file) will be emptied before editing";
 
     dc_verbose::
@@ -89,7 +85,7 @@ this effectively promises the full file content.";
     have_removed_indices.dc_verbose::
       "$(this.bundle): Remove syslog var: $(removed_indices)=$(cfdc_syslog:set.removed[$(removed_indices)])";
 
-    have_path_prefix.dc_verbose::
+    dc_verbose::
       "$(this.bundle): I repaired $(syslog_file), syslog needs to be reloaded"
       ifvarclass => "syslog_reload";
 

--- a/sketches/system/tzconfig/main.cf
+++ b/sketches/system/tzconfig/main.cf
@@ -19,31 +19,31 @@ bundle agent set(runenv, metadata, timezone, zoneinfo_dir)
 
   files:
     timezone_exists.(ubuntu|debian|gentoo)::
-      "$(path_prefix)/etc/timezone"
+      "/etc/timezone"
       handle        => "tzconfig_files_etc_timezone",
       edit_defaults => default:empty,
       create        => "true",
       edit_line     => default:insert_lines("$(timezone)"),
-      perms         => dc_test_aware_mog("644", "root", "root"),
+      perms         => default:mog("644", "root", "root"),
       comment       => "Debian and Gentoo based systems also use the /etc/timezone file";
 
     timezone_exists.(redhat|centos)::
-      "$(path_prefix)/etc/sysconfig/clock"
+      "/etc/sysconfig/clock"
       handle     => "tzconfig_files_etc_sysconfig_clock",
       create     => "true",
       edit_line  => default:replace_or_add("^ZONE=.*", 'ZONE="$(timezone)"'),
-      perms      => dc_test_aware_mog("644", "root", "root"),
+      perms      => default:mog("644", "root", "root"),
       comment    => "Redhat like systems use /etc/sysconfig/clock for
 the Time and Date Properties Tool
 (system-config-date), and editing it does not
 change the system timezone.";
 
     timezone_exists.linux::
-      "$(path_prefix)/etc/localtime"
+      "/etc/localtime"
       handle            => "tzconfig_files_etc_localtime",
       copy_from         => cfdc_tzconfig:copy_zoneinfo("$(tz_file)"),
       classes           => default:if_repaired("tz_updated"),
-      perms             => dc_test_aware_mog("644", "root", "root"),
+      perms             => default:mog("644", "root", "root"),
       move_obstructions => "true",
       comment           => "Copy the proper timezone file in place. We dont use
 a symlink because that might cause problems across
@@ -70,20 +70,4 @@ body copy_from copy_zoneinfo(source)
       source => "$(source)";
       copylink_patterns => { ".*", };
       compare => "hash";
-}
-
-body perms dc_test_aware_mog(mode, user, group)
-# @brief Set the file's mode, owner and group based on the `dc_test` class
-# @param mode The new mode
-# @param user The username of the new owner (if `dc_test`, `$(this.promiser_uid)`)
-# @param group The group name (if `dc_test`, `$(this.promiser_gid)`)
-{
-    any::
-      mode   => "$(mode)";
-    not_test::
-      owners => { "$(user)" };
-      groups => { "$(group)" };
-    dc_test::
-      owners => { $(this.promiser_uid) };
-      groups => { $(this.promiser_gid) };
 }

--- a/sketches/system/users/main.cf
+++ b/sketches/system/users/main.cf
@@ -7,7 +7,6 @@ bundle agent ensure_users(runenv, metadata, users, group, homedir, shell)
 {
 #@include "REPO/sketch_template/standard.inc"
   users:
-    !dc_test::
       "$(users)" -> {"PCI-DSS-2", "Baseline_developers_2_3"}
       policy => "present",
       home_dir => "$(homedir)/$(users)",
@@ -17,9 +16,7 @@ bundle agent ensure_users(runenv, metadata, users, group, homedir, shell)
       home_bundle => setup_home_dir($(users), $(homedir));
 
   reports:
-    dc_verbose.dc_test::
-      "$(dcbundle): simulating user = $(users) with group $(group), home dir $(homedir) and shell $(shell)";
-    dc_verbose.!dc_test::
+    dc_verbose::
       "$(dcbundle): ensuring user = $(users) with group $(group), home dir $(homedir) and shell $(shell)";
 }
 

--- a/sketches/utilities/dropdir/main.cf
+++ b/sketches/utilities/dropdir/main.cf
@@ -36,7 +36,7 @@ bundle agent dropdir_cleanit(script, days, id)
       "ago" int => ago(0, 0, $(days), 0, 0, 0);
 
   files:
-    cleanit.!dc_test::
+    cleanit::
       "$(script)"
       delete => default:tidy,
       classes => default:if_ok("$(pc)_cleaned");
@@ -47,10 +47,6 @@ bundle agent dropdir_cleanit(script, days, id)
       "$(dcbundle): $(script) is older than $(days) days, cleaning..." ifvarclass => "cleanit";
       "$(dcbundle): $(script) is newer than $(days) days, leaving it" ifvarclass => "recent";
       "$(dcbundle): $(script) was cleaned" ifvarclass => "$(pc)_cleaned";
-
-    cleanit.dc_test::
-      "$(dcbundle): in test mode, simulating that $(script) was cleaned"
-      handle => "$(id)_script_simulate_clean";
 }
 
 bundle agent dropdir_report(cmd, context, id, pname)

--- a/sketches/utilities/run_once/main.cf
+++ b/sketches/utilities/run_once/main.cf
@@ -64,7 +64,7 @@ bundle agent runit(cmd, context, id, pname)
       "contexts_found" expression => classify($(contexts));
 
   commands:
-      "$(run.exec_prefix)$(cmd)"
+      "$(cmd)"
       contain => default:in_shell,
       comment => "Run the given command iff the context is true and we haven't run it before.",
       ifvarclass => concat(canonify($(pname)), "_unknown.contexts_found"),

--- a/sketches/utilities/run_withdata/main.cf
+++ b/sketches/utilities/run_withdata/main.cf
@@ -16,7 +16,6 @@ bundle agent run(runenv, metadata, script, parameters)
       "made_jfile" expression => fileexists($(jfile));
 
   methods:
-    !dc_test::
       "writeit" usebundle => default:file_make($(jfile), $(pstring)),
       classes => default:scoped_classes_generic("bundle", "write"),
       inherit => "true";
@@ -32,8 +31,6 @@ bundle agent run(runenv, metadata, script, parameters)
   reports:
     dc_verbose::
       "$(dcbundle): The unique ID is $(activation_id) and the JSON parameter file is $(jfile)";
-    dc_test::
-      "$(dcbundle): Simulating execution of '$(script) $(jfile)'";
 }
 
 bundle agent run_fromfile(runenv, metadata, script, jfile)
@@ -44,7 +41,6 @@ bundle agent run_fromfile(runenv, metadata, script, jfile)
       "have_jfile" expression => fileexists($(jfile));
 
   methods:
-    !dc_test::
       "runit" usebundle => runit($(script), $(jfile)),
       ifvarclass => "have_jfile",
       inherit => "true";
@@ -52,13 +48,11 @@ bundle agent run_fromfile(runenv, metadata, script, jfile)
   reports:
     dc_verbose::
       "$(dcbundle): The JSON parameter file is $(jfile)";
-    dc_test::
-      "$(dcbundle): Simulating execution of '$(script) $(jfile)'";
 }
 
 bundle agent runit(cmd, jfile)
 {
   commands:
-      "$(run.exec_prefix)$(cmd) $(jfile)"
+      "$(cmd) $(jfile)"
       contain => default:in_shell;
 }


### PR DESCRIPTION
This is for all `enterprise_compatible` sketches.  I didn't bump their versions.

The API and `cf-sketch.pl` tools will still generate the `test` environment key, but it won't be used by any sketches.  The API's `self test` command will need to be modified or removed.

The docs haven't been updated.

I think this is a good idea.  Better to test inside Docker or with other tools than to burden sketches and authors with the testing framework.  It reduces code line count and complexity.