### PR TITLE
cf-sketch: fix relocate_path and use it in the tools/test/Makefile

### DIFF
--- a/tools/cf-sketch/cf-sketch.pl
+++ b/tools/cf-sketch/cf-sketch.pl
@@ -55,7 +55,6 @@ my %options = (
                force => 0,
                quiet => 0,
                verbose => 0,
-               test => '!any',
                ignore => 1,
                activated => 'any',
                veryverbose => 0,
@@ -79,7 +78,6 @@ GetOptions(\%options,
            "veryverbose|vv!",
            "generate!",
            "force|f!",
-           "test:s",
            "activated:s",
            "installsource|is=s",
            "cfpath=s",
@@ -140,9 +138,6 @@ EOHIPPUS
 $options{verbose} = 1 if $options{veryverbose};
 
 # Define default internal environment
-$options{test} = '!any' if !$options{test};
-my $env_test = $options{test};
-
 $options{activated} = 'any' if !$options{activated};
 my $env_activated = $options{activated};
 
@@ -151,7 +146,6 @@ api_interaction({
                                         $options{environment} =>
                                         {
                                          activated => $env_activated,
-                                         test => $env_test,
                                          verbose => $options{verbose} ? 'any' : '!any',
                                         }
                                        }

--- a/tools/cf-sketch/cf-sketch.pl
+++ b/tools/cf-sketch/cf-sketch.pl
@@ -96,6 +96,7 @@ GetOptions(\%options,
            "deactivate-all|da",
            "activate|a=s%",
            "inputs=s",
+           "relocate_path:s",
 
            "runfile_header=s",
           );
@@ -357,6 +358,11 @@ sub api_interaction
     if (exists $options{runfile_header})
     {
         $opts->{runfile}->{header} = $options{runfile_header};
+    }
+
+    if (exists $options{relocate_path})
+    {
+        $opts->{runfile}->{relocate_path} = $options{relocate_path};
     }
 
     if (exists $options{make_cfsketches} || exists $options{make_readme})

--- a/tools/cf-sketch/perl-lib/DCAPI.pm
+++ b/tools/cf-sketch/perl-lib/DCAPI.pm
@@ -16,7 +16,7 @@ use DCAPI::Validation;
 use constant API_VERSION => '3.6.0';
 use constant CODER => JSON->new()->allow_barekey()->relaxed()->utf8()->allow_nonref();
 use constant CAN_CODER => JSON->new()->canonical()->utf8()->allow_nonref();
-use constant REQUIRED_ENVIRONMENT_KEYS => qw/activated test verbose/;
+use constant REQUIRED_ENVIRONMENT_KEYS => qw/activated verbose/;
 use constant OPTIONAL_ENVIRONMENT_KEYS => qw/qa rudder/;
 
 use Mo qw/build default builder coerce is required/;

--- a/tools/cf-sketch/perl-lib/DCAPI.pm
+++ b/tools/cf-sketch/perl-lib/DCAPI.pm
@@ -1339,7 +1339,7 @@ sub regenerate
     my @inputs;
     foreach my $a (@activations)
     {
-        push @inputs, $a->sketch()->get_inputs(undef, 10);
+        push @inputs, $a->sketch()->get_inputs($self->runfile()->{relocate_path}, 10);
         $self->log("Regenerate: adding inputs %s", \@inputs);
     }
 

--- a/tools/test/Makefile
+++ b/tools/test/Makefile
@@ -43,12 +43,6 @@ ifeq ($(V),1)
   EXTRA:=--verbose=any
 endif
 
-ifneq ($(T),)
-  EXTRA:= $(EXTRA) --test=$(T)
-else
-  EXTRA:= $(EXTRA) --test=any
-endif
-
 ifneq ($(A),)
   EXTRA:= $(EXTRA) --activated=$(A)
 else

--- a/tools/test/Makefile
+++ b/tools/test/Makefile
@@ -60,7 +60,7 @@ ifneq ($(FILTER),)
 endif
 
 CFSKETCH_BASE:=$(PWD)/../cf-sketch/cf-sketch.pl --installsource=$(SOURCEDIR)/cfsketches.json
-CFSKETCH:=$(CFSKETCH_BASE) --make_cfsketches --inputs $(DCDIR); $(CFSKETCH_BASE) --expert --cfpath=$(CFPATH) $(EXTRA) --force --inputs $(API_DIR)
+CFSKETCH:=$(CFSKETCH_BASE) --make_cfsketches --inputs $(DCDIR); $(CFSKETCH_BASE) --expert --cfpath=$(CFPATH) $(EXTRA) --force --inputs $(API_DIR) --relocate_path sketches
 CFSKETCH_DA:=rm $(API_RUNFILE); $(CFSKETCH) --deactivate-all --generate -v
 RUNNER:=$(CFPATH)/cf-agent -KI -f $(API_DIR)/promises.cf
 CFAPI:=$(PWD)/../cf-sketch/cf-dc-api.pl $(PWD)/../cf-sketch/config.json


### PR DESCRIPTION
This enables `relocate_path` again, making it possible to use DC with relocated inputs.